### PR TITLE
fix: only handle cli usage if called from cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ var jsdelivr = {
 };
 
 // Handle command line usage
-if(process.argv.length > 2) {
+if(require.main === module && process.argv.length > 2) {
     (function () {
         var method = process.argv[2];
         var term = process.argv[3];


### PR DESCRIPTION
If you use this package in an app programmatically and call that app with arguments, a search is triggered.

Example: Create a file ```app.js``` with just the line:  
```js
const jsdelivr = require('jsdelivr');
```

Now execute `$ node app foo bar`

Expected result: no output
Actual result:
```
Unknown method, assuming search.
(...result list of search for "bar"...)
```

I fixed this by checking if `require.main` is set to `module`.
This is only the case if the file was called directly from CLI.
https://nodejs.org/docs/latest/api/all.html#modules_accessing_the_main_module